### PR TITLE
Generate the next version for release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,31 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Find Next Version
+        id: version
+        run: |
+          declare -i newpost
+          latest=$(git describe --tags $(git rev-list --tags --max-count=1))
+          latestpre=$(echo "$latest" | awk '{split($0,a,"."); print a[1] "." a[2]}')
+          datepre=$(date --utc '+%Y.%m')
+          if [[ "$latestpre" == "$datepre" ]]; then
+              latestpost=$(echo "$latest" | awk '{split($0,a,"."); print a[3]}')
+              newpost=$latestpost+1
+          else
+              newpost=0
+          fi
+          echo Current version:    $latest
+          echo New target version: $datepre.$newpost
+          echo "::set-output name=version::$datepre.$newpost"
+
       - uses: release-drafter/release-drafter@v5
+        with:
+          tag: ${{ steps.version.outputs.version }}
+          name: ${{ steps.version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is the same logic as we use in other repos like the supervisor