### PR TITLE
Add Khadas VIM3

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -15,6 +15,7 @@ jobs:
         machine:
           - generic-x86-64
           - intel-nuc
+          - khadas-vim3
           - odroid-c2
           - odroid-c4
           - odroid-n2

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -55,7 +55,7 @@ jobs:
       run: echo "BUILD_ARGS=--test" >> $GITHUB_ENV
 
     - name: Build landingpage
-      uses: home-assistant/builder@2021.06.2
+      uses: home-assistant/builder@2021.07.0
       with:
         args: |
           $BUILD_ARGS \


### PR DESCRIPTION
Add Khadas VIM3 machine. VIM3 is based on Amlogic A311D SoC with
2xCortex-A53 and 4xCortex-A73.

Related: https://github.com/home-assistant/builder/pull/104