### PR TITLE
Update URL to Home Assistant app

### DIFF
--- a/rootfs/usr/share/www/index.html
+++ b/rootfs/usr/share/www/index.html
@@ -37,7 +37,7 @@
           <div class="app-links">
             <a
               target="_blank"
-              href="https://apps.apple.com/us/app/home-assistant/id1099568401?mt=8"
+              href="https://apps.apple.com/app/home-assistant/id1099568401?mt=8"
               ><img
                 alt="Get it on the Apple App Store"
                 src="/landingpage/static/apple-badge.svg"


### PR DESCRIPTION
Removes "us" from the apple app store URL.