### PR TITLE
Completely match the new Supervisor log timestamp format

### DIFF
--- a/rootfs/usr/share/www/static/scripts.js
+++ b/rootfs/usr/share/www/static/scripts.js
@@ -87,7 +87,7 @@ function fetchLogs() {
         }
         var scrolledDown = logElement.scrollTop + logElement.clientHeight === logElement.scrollHeight;
         logElement.innerHTML = text
-          .replace(/^[\[\d \-:\]]*/gm, "")
+          .replace(/^[\[\d \-:.\]]*/gm, "")
           .replace(/^(INFO|WARNING|ERROR)\s\(\w+\)\s(.*)\n/gm, "<span class='$1'>$2</span>\n")
         if (scrolledDown) {
           // Scroll content down if it was already scrolled down


### PR DESCRIPTION
With the recent change which added milliseconds to the timestamp the timestamp removal regex used in the landing page frontend did not completely remove the timestamp anymore. This also lead to log level not match correctly, and hence loss of log coloring.

Correctly match the log timestamp.

See also: https://github.com/home-assistant/supervisor/pull/4954