### PR TITLE
Poll the absolute path of the manifest.json file

### DIFF
--- a/rootfs/usr/share/www/static/scripts.js
+++ b/rootfs/usr/share/www/static/scripts.js
@@ -61,7 +61,7 @@ self.fetch ||
   });
 
 function testAvailable() {
-  fetch("./manifest.json").then(function (res) {
+  fetch("/manifest.json").then(function (res) {
     if (res.ok) {
       location.reload();
     } else {


### PR DESCRIPTION
Instead of using a relative path to manifest.json use an absolute path. This makes sure that we detect that Home Assistant Core is available also on our Apps, which navigate to `/auth/authorize?...` by default. The relative path then polls the wrong location `/auth/manifest.json`.

With the absolute path we make sure that the correct location is polled on our Apps as well.

Fixes: home-assistant/android#4576