### PR TITLE
Add proxy for network and resolution endpoints

### DIFF
--- a/http.go
+++ b/http.go
@@ -93,7 +93,6 @@ func httpSupervisorProxy(w http.ResponseWriter, r *http.Request) {
 
 	// Update the request path to be forwarded
 	r.URL.Path = "/" + subPath + cleanPath
-	log.Printf("Sanitized and remapped path: %s", r.URL.Path)
 
 	// Create the reverse proxy
 	proxy := httputil.NewSingleHostReverseProxy(u)

--- a/main.go
+++ b/main.go
@@ -27,6 +27,8 @@ func main() {
 	http.HandleFunc("/api/", httpUnauthorized)
 	http.HandleFunc("/auth/token", httpBad)
 	http.HandleFunc("/observer/logs", httpLogs)
+	http.HandleFunc("/supervisor/resolution/", httpSupervisorProxy)
+	http.HandleFunc("/supervisor/network/", httpSupervisorProxy)
 
 	// Serve static help files
 	staticFiles := http.FileServer(http.Dir(wwwRoot))


### PR DESCRIPTION
Forward the requests to the network and resolution endpoints to the Supervisor. This will allow the landing page to get insights when the Supervisor detects issues on first startup (e.g. problematic DNS servers). The network endpoint will allow to resolve these issues.

Note: This makes the two mentioned endpoints available unauthenticated. However, the landing page will be replaced with Core as soon as it has been downloaded, so this unauthenticated forwarding will only be during a brief phase on initial setup. A bad actor could also just setup a new user from the onboarding page at this point in time. So this effectly does not change the security posture.