### PR TITLE
Check host network connectivity

### DIFF
--- a/rootfs/usr/share/www/index.html
+++ b/rootfs/usr/share/www/index.html
@@ -55,11 +55,14 @@
         </svg>
         <div class="alert-content">
           <p>
-          There is a network issue on the host operating system, which prevents Home Assistant from installing completely.
-          This might be DNS related, currently using <span id="current_dns"></span> as DNS.
+            Home Assistant OS detected a networking issue in your setup. As part of the initial
+            setup, Home Assistant OS downloads the latest version of Home Assistant Core. This
+            networking issue prevents this download. The network issue might be DNS related.
+            The currently used DNS service is: <span id="current_dns"></span>.
           </p>
           <p>
-          Update your routers configuration if you want to use a custom DNS. Alternatively, you can try a public DNS.
+            To resolve this, you can try a different DNS server. Select one of the options below.
+            Alternatively, change your router configuration to use your own custom DNS server. 
           </p>
         </div>
       </div>

--- a/rootfs/usr/share/www/index.html
+++ b/rootfs/usr/share/www/index.html
@@ -26,7 +26,7 @@
         </div>
       </div>
     </div>
-    <div class="state-error">
+    <div id="state-error" class="error">
       <h1>Error installing Home Assistant</h1>
       <div role="alert" class="alert">
         <svg class="alert-icon" preserveAspectRatio="xMidYMid meet" focusable="false" role="img" aria-hidden="true"
@@ -40,6 +40,32 @@
         <div class="alert-content">
           An error occured while installing Home Assistant, check the logs below for more information.
         </div>
+      </div>
+    </div>
+    <div id="state-network-issue" class="warning">
+      <h1>Networking issue detected</h1>
+      <div role="alert" class="alert warning">
+        <svg class="alert-icon" preserveAspectRatio="xMidYMid meet" focusable="false" role="img" aria-hidden="true"
+          viewBox="0 0 24 24">
+          <g>
+            <path
+              d="M11,15H13V17H11V15M11,7H13V13H11V7M12,2C6.47,2 2,6.5 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20Z">
+            </path>
+          </g>
+        </svg>
+        <div class="alert-content">
+          <p>
+          There is a network issue on the host operating system, which prevents Home Assistant from installing completely.
+          This might be DNS related, currently using <span id="current_dns"></span> as DNS.
+          </p>
+          <p>
+          Update your routers configuration if you want to use a custom DNS. Alternatively, you can try a public DNS.
+          </p>
+        </div>
+      </div>
+      <div class="actions">
+        <button id="try_cloudflare_dns" class="button">Try Cloudflare DNS</button>
+        <button id="try_google_dns" class="button">Try Google DNS</button>
       </div>
     </div>
     <pre id="log"></pre>

--- a/rootfs/usr/share/www/index.html
+++ b/rootfs/usr/share/www/index.html
@@ -64,8 +64,8 @@
         </div>
       </div>
       <div class="actions">
-        <button id="try_cloudflare_dns" class="button">Use Cloudflare DNS</button>
-        <button id="try_google_dns" class="button">Use Google DNS</button>
+        <button id="use_cloudflare_dns" class="button">Use Cloudflare DNS</button>
+        <button id="use_google_dns" class="button">Use Google DNS</button>
       </div>
     </div>
     <pre id="log"></pre>

--- a/rootfs/usr/share/www/index.html
+++ b/rootfs/usr/share/www/index.html
@@ -64,8 +64,8 @@
         </div>
       </div>
       <div class="actions">
-        <button id="try_cloudflare_dns" class="button">Try Cloudflare DNS</button>
-        <button id="try_google_dns" class="button">Try Google DNS</button>
+        <button id="try_cloudflare_dns" class="button">Use Cloudflare DNS</button>
+        <button id="try_google_dns" class="button">Use Google DNS</button>
       </div>
     </div>
     <pre id="log"></pre>

--- a/rootfs/usr/share/www/static/scripts.js
+++ b/rootfs/usr/share/www/static/scripts.js
@@ -121,6 +121,10 @@ function fetchNetworkInfo() {
       if (!data.data.host_internet) {
         document.body.classList.add("network-issue");
       }
+      else
+      {
+        document.body.classList.remove("network-issue");
+      }
 
       if (document.body.classList.contains("network-issue")) {
         const primaryInterface = data.data.interfaces.find(intf => intf.primary);

--- a/rootfs/usr/share/www/static/scripts.js
+++ b/rootfs/usr/share/www/static/scripts.js
@@ -140,7 +140,7 @@ function fetchNetworkInfo() {
   }, scheduleFetchNetworkInfo());
 }
 
-const scheduleNetworkTimeout;
+var scheduleNetworkTimeout;
 
 function scheduleFetchNetworkInfo() {
   clearTimeout(scheduleNetworkTimeout);

--- a/rootfs/usr/share/www/static/scripts.js
+++ b/rootfs/usr/share/www/static/scripts.js
@@ -124,7 +124,7 @@ function fetchNetworkInfo() {
 
       if (document.body.classList.contains("network-issue")) {
         const primaryInterface = data.data.interfaces.find(intf => intf.primary);
-        var dnsElement = document.getElementById("current_dns");
+        const dnsElement = document.getElementById("current_dns");
         if (!primaryInterface) {
           dnsElement.innerText = "(no primary interface)";
         } else {
@@ -136,7 +136,7 @@ function fetchNetworkInfo() {
   }, scheduleFetchNetworkInfo());
 }
 
-var scheduleNetworkTimeout;
+const scheduleNetworkTimeout;
 
 function scheduleFetchNetworkInfo() {
   clearTimeout(scheduleNetworkTimeout);

--- a/rootfs/usr/share/www/static/scripts.js
+++ b/rootfs/usr/share/www/static/scripts.js
@@ -106,7 +106,7 @@ function scheduleTry() {
   setTimeout(testAvailable, 5000);
 }
 
-var scheduleTimeout;
+let scheduleTimeout;
 
 function scheduleFetchLogs() {
   clearTimeout(scheduleTimeout);
@@ -142,7 +142,7 @@ function fetchSupervisorInfo() {
   scheduleFetchSupervisorInfo();
 }
 
-var scheduleSupervisorTimeout;
+let scheduleSupervisorTimeout;
 
 function scheduleFetchSupervisorInfo() {
   clearTimeout(scheduleSupervisorTimeout);

--- a/rootfs/usr/share/www/static/scripts.js
+++ b/rootfs/usr/share/www/static/scripts.js
@@ -175,11 +175,11 @@ function toggleLogs(event) {
   }
 }
 
-document.getElementById("try_cloudflare_dns").addEventListener("click", function() {
+document.getElementById("use_cloudflare_dns").addEventListener("click", function() {
   setDns(["1.1.1.1", "1.0.0.1"], ["2606:4700:4700::1111", "2606:4700:4700::1001"]);
 });
 
-document.getElementById("try_google_dns").addEventListener("click", function() {
+document.getElementById("use_google_dns").addEventListener("click", function() {
   setDns(["8.8.8.8", "8.8.4.4"], ["2001:4860:4860::8888", "2001:4860:4860::8844"]);
 });
 

--- a/rootfs/usr/share/www/static/scripts.js
+++ b/rootfs/usr/share/www/static/scripts.js
@@ -98,7 +98,8 @@ function fetchLogs() {
         }
       });
     }
-  }, scheduleFetchLogs());
+  });
+  scheduleFetchLogs();
 }
 
 function scheduleTry() {
@@ -112,7 +113,7 @@ function scheduleFetchLogs() {
   scheduleTimeout = setTimeout(fetchLogs, 5000);
 }
 
-function fetchNetworkInfo() {
+function fetchSupervisorInfo() {
   fetch("/supervisor/network/info").then(function (res) {
     if (!res.ok)
       return;
@@ -137,19 +138,20 @@ function fetchNetworkInfo() {
       }
 
     });
-  }, scheduleFetchNetworkInfo());
+  });
+  scheduleFetchSupervisorInfo();
 }
 
-var scheduleNetworkTimeout;
+var scheduleSupervisorTimeout;
 
-function scheduleFetchNetworkInfo() {
-  clearTimeout(scheduleNetworkTimeout);
-  scheduleNetworkTimeout = setTimeout(fetchNetworkInfo, 5000);
+function scheduleFetchSupervisorInfo() {
+  clearTimeout(scheduleSupervisorTimeout);
+  scheduleSupervisorTimeout = setTimeout(fetchSupervisorInfo, 5000);
 }
 
 scheduleTry();
 fetchLogs();
-fetchNetworkInfo();
+fetchSupervisorInfo();
 
 document.getElementById("show_logs").addEventListener("click", toggleLogs);
 function toggleLogs(event) {
@@ -228,7 +230,7 @@ function setDns(ipv4nameservers, ipv6nameservers) {
       if (!response.ok) {
           throw new Error('Failed to update the interface');
       }
-      fetchNetworkInfo();
+      fetchSupervisorInfo();
       return response.json();
   })
   .then(data => {

--- a/rootfs/usr/share/www/static/styles.css
+++ b/rootfs/usr/share/www/static/styles.css
@@ -30,15 +30,15 @@ body {
   white-space: nowrap;
 }
 
-.error .state-normal {
+.supervisor-error .state-normal {
   display: none;
 }
 
-.state-error {
+#state-error {
   display: none;
 }
 
-.error .state-error {
+.supervisor-error #state-error {
   display: block;
 }
 
@@ -60,6 +60,9 @@ body {
   pointer-events: none;
   content: "";
   border-radius: 4px;
+}
+
+.error .alert::after {
   background-color: #db4437;
 }
 
@@ -74,6 +77,31 @@ body {
   text-align: left;
   margin-left: 8px;
   margin-right: 0;
+}
+
+#state-network-issue {
+  display: none;
+}
+
+.network-issue #state-network-issue {
+  display: block;
+}
+
+.network-issue .state-normal {
+  display: none;
+}
+
+.warning .alert-icon {
+  fill: #ffa600;
+}
+
+.warning .alert::after {
+  background-color: #ffa600;
+}
+
+.warning .actions {
+  display: flex;
+  margin-bottom: 16px;
 }
 
 .header {


### PR DESCRIPTION
Check host network connectivity and offer DNS alternatives in case host internet is not available. This allows users with broken DNS setup to configure the host network with a working DNS.

Requires https://github.com/home-assistant/supervisor/pull/5321.

![image](https://github.com/user-attachments/assets/caf06f55-797a-40a4-b1b4-93a63783d465)

