### PR TITLE
Autoupdate frontend to draft PR

### DIFF
--- a/.github/workflows/update_frontend.yml
+++ b/.github/workflows/update_frontend.yml
@@ -69,5 +69,6 @@ jobs:
           commit-message: "Autoupdate frontend to version ${{ needs.check-version.outputs.latest_tag }}"
           branch: autoupdate-frontend
           base: main
+          draft: true
           sign-commits: true
           title: "Autoupdate frontend to version ${{ needs.check-version.outputs.latest_tag }}"


### PR DESCRIPTION
Create frontend autoupdates PR only as draft.

To avoid unnecessary merges. Whenever we know about a relevant change in frontend for landingpage we can manually mark it is ready for review and merge.