### PR TITLE
Add ping supervisor proxy

### DIFF
--- a/http.go
+++ b/http.go
@@ -70,8 +70,8 @@ func httpSupervisorProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Strip "/supervisor/" from the path
-	trimmedPath := strings.TrimPrefix(r.URL.Path, "/supervisor/")
+	// Strip "/supervisor-api/" from the path
+	trimmedPath := strings.TrimPrefix(r.URL.Path, "/supervisor-api/")
 
 	// Split the path into parts, the first part is the subpath (e.g., resolution or network)
 	parts := strings.SplitN(trimmedPath, "/", 2)

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func main() {
 	http.HandleFunc("/api/", httpUnauthorized)
 	http.HandleFunc("/auth/token", httpBad)
 	http.HandleFunc("/observer/logs", httpLogs)
+	http.HandleFunc("/supervisor/supervisor/ping", httpSupervisorProxy)
 	http.HandleFunc("/supervisor/supervisor/logs", httpSupervisorProxy)
 	http.HandleFunc("/supervisor/supervisor/logs/follow", httpSupervisorProxy)
 	http.HandleFunc("/supervisor/resolution/", httpSupervisorProxy)

--- a/main.go
+++ b/main.go
@@ -29,11 +29,11 @@ func main() {
 	http.HandleFunc("/api/", httpUnauthorized)
 	http.HandleFunc("/auth/token", httpBad)
 	http.HandleFunc("/observer/logs", httpLogs)
-	http.HandleFunc("/supervisor/supervisor/ping", httpSupervisorProxy)
-	http.HandleFunc("/supervisor/supervisor/logs", httpSupervisorProxy)
-	http.HandleFunc("/supervisor/supervisor/logs/follow", httpSupervisorProxy)
-	http.HandleFunc("/supervisor/resolution/", httpSupervisorProxy)
-	http.HandleFunc("/supervisor/network/", httpSupervisorProxy)
+	http.HandleFunc("/supervisor-api/supervisor/ping", httpSupervisorProxy)
+	http.HandleFunc("/supervisor-api/supervisor/logs", httpSupervisorProxy)
+	http.HandleFunc("/supervisor-api/supervisor/logs/follow", httpSupervisorProxy)
+	http.HandleFunc("/supervisor-api/resolution/", httpSupervisorProxy)
+	http.HandleFunc("/supervisor-api/network/", httpSupervisorProxy)
 
 	// Serve static help files
 	staticFiles := http.FileServer(http.Dir(wwwRoot))


### PR DESCRIPTION
- To allow frontend to check supervisor status on initial load allow pinging the supervisor.
- Rename supervisor proxy prefix to `supervisor-api` to make it more understandable
- Frontend PR: home-assistant/frontend#24330