### PR TITLE
Remove release assets tarball on frontend update

### DIFF
--- a/.github/workflows/update_frontend.yml
+++ b/.github/workflows/update_frontend.yml
@@ -64,6 +64,9 @@ jobs:
           fileName: home_assistant_frontend_landingpage-${{ needs.check-version.outputs.latest_version }}.tar.gz
           extract: true
           out-file-path: rootfs/usr/share/www/
+      - name: Remove release assets archive
+        run: |
+          rm -f rootfs/usr/share/www/home_assistant_frontend_landingpage-*.tar.gz
       - name: Create PR
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
As the release-downloader action doesn't have the ability to remove the file after extracting it, remove it before creating the PR. Otherwise it clutters the Git repo and resulting image as well.