### PR TITLE
Run mDNS broadcast asynchronously

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,9 +42,11 @@ func main() {
 	http.Handle("/frontend_latest/", staticFiles)
 
 	// Start mDNS broadcast
-	log.Print("Start mDNS broadcast")
-	publishHomeAssistant()
-	defer mdns.Shutdown()
+	go func() {
+		log.Print("Start mDNS broadcast")
+		publishHomeAssistant()
+		defer mdns.Shutdown()
+	}()
 
 	// Run webserver
 	go func() {


### PR DESCRIPTION
Run mDNS in a goroutine so the landing page server starts also in cases when the outbound IP address can't be determined or the mDNS server fails to start for another reason.

This is easy to reproduce when the device has no network connectivity when it starts for the first time. In such case, the landing page errors with "connect: network is unreachable" and never starts after the cable is reconnected, leaving port 8123 unreachable until full Core is downloaded.

Since mDNS is not mission-critical, we shouldn't block the webserver from starting and just start the mDNS asynchronously.