### PR TITLE
Poll for address of Supervisor default interface for mDNS URL

### DIFF
--- a/http.go
+++ b/http.go
@@ -70,11 +70,7 @@ func httpSupervisorProxy(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Proxy request: %s", r.URL.Path)
 
 	// Base Supervisor URL
-	supervisorHost := "supervisor"
-
-	if development && os.Getenv("SUPERVISOR_HOST") != "" {
-		supervisorHost = os.Getenv("SUPERVISOR_HOST")
-	}
+	supervisorHost := getSupervisorHost()
 
 	u, err := url.Parse("http://" + supervisorHost + "/")
 	if err != nil {

--- a/http.go
+++ b/http.go
@@ -112,7 +112,7 @@ func httpSupervisorProxy(w http.ResponseWriter, r *http.Request) {
 	proxy := httputil.NewSingleHostReverseProxy(u)
 
 	// Add authorization header
-	r.Header.Add("Authorization", "Bearer "+os.Getenv("SUPERVISOR_TOKEN"))
+	setSupervisorAuthHeader(r)
 
 	switch cleanPath {
 	case "/logs":

--- a/main.go
+++ b/main.go
@@ -24,6 +24,15 @@ func getSupervisorHost() string {
 	return supervisorHost
 }
 
+func setSupervisorAuthHeader(r *http.Request) {
+	token := os.Getenv("SUPERVISOR_TOKEN")
+	if token != "" {
+		r.Header.Add("Authorization", "Bearer "+token)
+	} else {
+		log.Println("No SUPERVISOR_TOKEN set, request will be unauthenticated")
+	}
+}
+
 func main() {
 	development = (os.Getenv("DEVELOPMENT") == "True")
 

--- a/main.go
+++ b/main.go
@@ -14,6 +14,16 @@ var mdns *zeroconf.Server
 var wwwRoot string
 var development bool
 
+func getSupervisorHost() string {
+	supervisorHost := "supervisor"
+
+	if development && os.Getenv("SUPERVISOR_HOST") != "" {
+		supervisorHost = os.Getenv("SUPERVISOR_HOST")
+	}
+
+	return supervisorHost
+}
+
 func main() {
 	development = (os.Getenv("DEVELOPMENT") == "True")
 

--- a/mdns.go
+++ b/mdns.go
@@ -1,18 +1,41 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
 	"log"
 	"net"
+	"net/http"
+	"os"
+	"time"
 
 	"github.com/grandcat/zeroconf"
 	"github.com/rs/xid"
 )
 
+type Response struct {
+	Result  string         `json:"result"`
+	Message string         `json:"message,omitempty"`
+	Data    map[string]any `json:"data,omitempty"`
+}
+
 func publishHomeAssistant() {
 	var err error
 
+	var outboundIP net.IP
+
+	for {
+		outboundIP, err = getOutboundIP()
+		if outboundIP != nil {
+			break
+		}
+		log.Printf("Failed to get outbound IP, retrying in 5s: %s", err)
+		time.Sleep(5 * time.Second)
+	}
+
 	unique := xid.New()
-	hostURL := "http://" + getOutboundIP().String() + ":8123"
+	hostURL := "http://" + outboundIP.String() + ":8123"
 	params := []string{
 		"location_name=Home Assistant",
 		"uuid=",
@@ -31,21 +54,76 @@ func publishHomeAssistant() {
 	}
 }
 
-// Get preferred outbound ip of this machine
-// https://stackoverflow.com/a/37382208
-// Can be removed after Supervisor v248 with new lookup
-func getOutboundIP() net.IP {
-	conn, err := net.Dial("udp", "8.8.8.8:80")
-	if err != nil {
-		log.Fatal(err)
+// Get the first IPv4 address from the interface information
+func getFirstIPv4Address(iface map[string]any) (net.IP, error) {
+	ipv4Data, ok := iface["ipv4"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("no ipv4 addresses found")
 	}
-	defer func() {
-		if err := conn.Close(); err != nil {
-			log.Printf("error closing mdns connection: %v", err)
+
+	addresses, ok := ipv4Data["address"].([]any)
+	if !ok || len(addresses) == 0 {
+		return nil, fmt.Errorf("empty ipv4 address list")
+	}
+
+	addr, ok := addresses[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("can't parse first ipv4 address")
+	}
+
+	ip, _, err := net.ParseCIDR(addr)
+
+	if err != nil {
+		return nil, fmt.Errorf("invalid IPv4 address: %s", err)
+	}
+
+	return ip, nil
+}
+
+// Get IP address of the default interface from Supervisor
+func getOutboundIP() (net.IP, error) {
+	supervisorHost := getSupervisorHost()
+
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "http://"+supervisorHost+"/network/interface/default/info", nil)
+
+	if err != nil {
+		return nil, fmt.Errorf("can't create request to Supervisor: %s", err)
+	}
+
+	req.Header.Add("Authorization", "Bearer "+os.Getenv("SUPERVISOR_TOKEN"))
+
+	response, err := client.Do(req)
+	if err == nil {
+		defer response.Body.Close()
+	}
+
+	if err != nil || response.StatusCode >= 300 {
+		var errorMsg string
+
+		if err == nil {
+			if data, err := io.ReadAll(response.Body); err == nil {
+				errorMsg = string(data)
+			} else {
+				errorMsg = err.Error()
+			}
+		} else {
+			errorMsg = err.Error()
 		}
-	}()
 
-	localAddr := conn.LocalAddr().(*net.UDPAddr)
+		return nil, fmt.Errorf("can't get default interface from Supervisor: %s", errorMsg)
+	}
 
-	return localAddr.IP
+	var responseData Response
+
+	if err := json.NewDecoder(response.Body).Decode(&responseData); err != nil {
+		return nil, fmt.Errorf("can't parse default interface data: %s", err)
+	}
+
+	ipv4Addr, err := getFirstIPv4Address(responseData.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	return ipv4Addr, nil
 }

--- a/mdns.go
+++ b/mdns.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/grandcat/zeroconf"
@@ -91,7 +90,7 @@ func getOutboundIP() (net.IP, error) {
 		return nil, fmt.Errorf("can't create request to Supervisor: %s", err)
 	}
 
-	req.Header.Add("Authorization", "Bearer "+os.Getenv("SUPERVISOR_TOKEN"))
+	setSupervisorAuthHeader(req)
 
 	response, err := client.Do(req)
 	if err == nil {


### PR DESCRIPTION
Outstanding comment mentions the hacky way for obtaining the outbound IP address should be replaced by API from home-assistant/supervisor#2115. Poll this API periodically with 5s retry interval in case the IP can't be determined or parsed from the response.

This still ignores IPv6-only deployment of HA, however, in that case the landing page should still be reachable, just not discoverable through mDNS (combined with #164).