### PR TITLE
Drop build for unsupported targets

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -18,25 +18,16 @@ jobs:
       matrix:
         machine:
           - generic-x86-64
-          - intel-nuc
           - khadas-vim3
           - odroid-c2
           - odroid-c4
           - odroid-m1
           - odroid-n2
-          - odroid-xu
-          - qemuarm
           - qemuarm-64
-          - qemux86
           - qemux86-64
-          - raspberrypi
-          - raspberrypi2
-          - raspberrypi3
           - raspberrypi3-64
-          - raspberrypi4
           - raspberrypi4-64
           - raspberrypi5-64
-          - tinker
           - yellow
           - green
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,8 @@ COPY . .
 
 # Build
 RUN \
-        if [ "${BUILD_ARCH}" = "armhf" ]; then \
-            CGO_ENABLED=0 GOARM=6 GOARCH=arm go build -ldflags="-s -w"; \
-        elif [ "${BUILD_ARCH}" = "armv7" ]; then \
-            CGO_ENABLED=0 GOARM=7 GOARCH=arm go build -ldflags="-s -w"; \
-        elif [ "${BUILD_ARCH}" = "aarch64" ]; then \
+        if [ "${BUILD_ARCH}" = "aarch64" ]; then \
             CGO_ENABLED=0 GOARCH=arm64 go build -ldflags="-s -w"; \
-        elif [ "${BUILD_ARCH}" = "i386" ]; then \
-            CGO_ENABLED=0 GOARCH=386 go build -ldflags="-s -w"; \
         elif [ "${BUILD_ARCH}" = "amd64" ]; then \
             CGO_ENABLED=0 GOARCH=amd64 go build -ldflags="-s -w"; \
         else \


### PR DESCRIPTION
Drop build of images for all unsupported targets (32bit platforms) and intel-nuc (which has been renamed to generic-x86-64 in OS 6 - way beyond what is officially supported).

Also convert Dockerfile with dos2unix.