### PR TITLE
Change default HTTP port to 80

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"name": "Landingpage",
 	"image": "mcr.microsoft.com/vscode/devcontainers/go:1.19",
-	"appPort": [ "8830:8123" ],
+	"appPort": [ "8830:80" ],
 	"postCreateCommand": "go mod download",
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
 	"containerEnv": {

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 Home Assistant OS pre-installed landing page. This is a small, temporary
 landing page shipped with Home Assistant OS so something is displayed while
 Supervisor is downloading the full version of Home Assistant Core on first
-startup. The landing page opens a web server on port 8123 and publishes DNS-SD
+startup. The landing page opens a web server on port 80 and publishes DNS-SD
 discovery information. From that perspective the landing page is like a
 stripped down version of Home Assistant Core.

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -9,6 +10,9 @@ import (
 
 	"github.com/grandcat/zeroconf"
 )
+
+// httpPort is used for the actual HTTP server and the mDNS announcement
+const httpPort = 80
 
 var mdns *zeroconf.Server
 var wwwRoot string
@@ -69,8 +73,9 @@ func main() {
 
 	// Run webserver
 	go func() {
-		log.Print("Start webserver on http://0.0.0.0:8123")
-		if err := http.ListenAndServe(":8123", nil); err != nil {
+		listenAddr := fmt.Sprintf(":%d", httpPort)
+		log.Printf("Start webserver on http://0.0.0.0%s", listenAddr)
+		if err := http.ListenAndServe(listenAddr, nil); err != nil {
 			log.Fatal(err)
 		}
 	}()

--- a/mdns.go
+++ b/mdns.go
@@ -34,7 +34,7 @@ func publishHomeAssistant() {
 	}
 
 	unique := xid.New()
-	hostURL := "http://" + outboundIP.String() + ":8123"
+	hostURL := fmt.Sprintf("http://%s:%d", outboundIP.String(), httpPort)
 	params := []string{
 		"location_name=Home Assistant",
 		"uuid=",
@@ -47,7 +47,7 @@ func publishHomeAssistant() {
 	}
 
 	log.Printf("Publish %s to _home-assistant._tcp", hostURL)
-	mdns, err = zeroconf.Register("homeassistant-"+unique.String(), "_home-assistant._tcp", "local.", 8123, params, nil)
+	mdns, err = zeroconf.Register("homeassistant-"+unique.String(), "_home-assistant._tcp", "local.", httpPort, params, nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Refactor the hardcoded 8123 to a single source of truth in the main Go file and change it to the standard HTTP port 80.

Closes #187