### PR TITLE
Add jobs API to landing page

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 	http.HandleFunc("/supervisor-api/supervisor/logs/follow", httpSupervisorProxy)
 	http.HandleFunc("/supervisor-api/resolution/", httpSupervisorProxy)
 	http.HandleFunc("/supervisor-api/network/", httpSupervisorProxy)
+	http.HandleFunc("/supervisor-api/jobs/", httpSupervisorProxy)
 
 	// Serve static help files
 	staticFiles := http.FileServer(http.Dir(wwwRoot))


### PR DESCRIPTION
This allows to inspect the home_assistant_core_install job from the landing page, which is useful to see the progress of the installation. Currently the job does not expose errors (they are handled within the job and not propagate to the jobs error handling system). So this is only useful to display installation progress.