### PR TITLE
Listen also on port 80 and redirect transparently to 8123

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ Home Assistant OS pre-installed landing page. This is a small, temporary
 landing page shipped with Home Assistant OS so something is displayed while
 Supervisor is downloading the full version of Home Assistant Core on first
 startup. The landing page opens a web server on port 8123 and publishes DNS-SD
-discovery information. From that perspective the landing page is like a
+discovery information. It also listens on port 80 and redirects all requests
+there to port 8123. From that perspective the landing page is like a
 stripped down version of Home Assistant Core.

--- a/http.go
+++ b/http.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -13,6 +14,15 @@ import (
 )
 
 var regexASCII = regexp.MustCompile(`\x1b\[\d+m`)
+
+func httpRedirect(w http.ResponseWriter, r *http.Request) {
+	host := r.Host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	target := "http://" + net.JoinHostPort(host, "8123") + r.URL.RequestURI()
+	http.Redirect(w, r, target, http.StatusFound)
+}
 
 func httpIndex(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" && r.URL.Path != "/auth/authorize" {

--- a/main.go
+++ b/main.go
@@ -87,6 +87,14 @@ func main() {
 		}
 	}()
 
+	// Redirect requests on port 80 to port 8123
+	go func() {
+		log.Print("Start redirect server on http://0.0.0.0:80")
+		if err := http.ListenAndServe(":80", http.HandlerFunc(httpRedirect)); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
 	signalChannel := make(chan os.Signal, 2)
 	signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM)
 	for {


### PR DESCRIPTION
As we don't want to switch to port 80 just yet, but we want to make the landingpage/onboarding reachable also on that port when older OS version is used after updating the docs, simply redirect all requests with HTTP 302 to respective URLs on port 8123.

Refs #187