### PR TITLE
Fix cache image tag in builder workflow

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -78,6 +78,7 @@ jobs:
         uses: home-assistant/builder/actions/build-image@62a1597b84b3461abad9816d9cd92862a2b542c3 # 2026.03.2
         with:
           arch: ${{ matrix.arch }}
+          cache-image-tag: landingpage
           container-registry-password: ${{ secrets.GITHUB_TOKEN }}
           image: ghcr.io/home-assistant/${{ matrix.machine }}-homeassistant
           image-tags: |


### PR DESCRIPTION
Since landingpage uses the same image name as Core, the builder action fetches latest Core image and verify it with this repo's subject which fails. Set the landingpage tag as the image used as the cache.