### PR TITLE
Reorder build matrix include to fix amd64 builds

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -58,6 +58,9 @@ jobs:
           - yellow
           - green
         include:
+          # aarch64 by default (keep first so the amd64 overrides below win)
+          - arch: aarch64
+            runs-on: ubuntu-24.04-arm
           # amd64 machines
           - machine: generic-x86-64
             arch: amd64
@@ -65,9 +68,6 @@ jobs:
           - machine: qemux86-64
             arch: amd64
             runs-on: ubuntu-24.04
-          # Default for the rest: aarch64 on native ARM runner
-          - arch: aarch64
-            runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
It appears that the include matrix semantics was wrong, with the last include not setting "machine" overriding all builds including those amd64 ones to build on ARM nodes. Set the "default include" first to fix this.