### PR TITLE
Use literal "landingpage" version label to workaround Supervisor landingpage detection

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -83,5 +83,7 @@ jobs:
           image: ghcr.io/home-assistant/${{ matrix.machine }}-homeassistant
           image-tags: |
             landingpage
+            landingpage-${{ needs.init.outputs.version }}
           push: ${{ needs.init.outputs.publish == 'true' }}
-          version: ${{ needs.init.outputs.version }}
+          # version must be "landingpage" until this is resolved: https://github.com/home-assistant/supervisor/issues/6934
+          version: landingpage


### PR DESCRIPTION
Supervisor reads the io.hass.version label to check if the installed Core image version is a landingpage. This should be fixed by home-assistant/supervisor#6935 but before that, we need landingpage that's compatible with older Supervisors, so revert to the old labeling used before we migrated to the new builder.

Also, push version-suffixed tag to the Docker registry, so we can compare and backtrace older versions easier (this change can stay after fixing the Supervisor detection).

Refs home-assistant/supervisor#6934